### PR TITLE
Nanny log script parent name

### DIFF
--- a/src/main/java/perf/qdup/cmd/Cmd.java
+++ b/src/main/java/perf/qdup/cmd/Cmd.java
@@ -649,6 +649,10 @@ public abstract class Cmd {
         return rtrn;
     }
 
+    public Cmd getParent() {
+        return parent;
+    }
+
     @Override
     public int hashCode(){
         return getUid();

--- a/src/main/java/perf/qdup/cmd/Dispatcher.java
+++ b/src/main/java/perf/qdup/cmd/Dispatcher.java
@@ -154,11 +154,14 @@ public class Dispatcher {
                     if(command instanceof Sh){
                         //TODO check for common prompts in output?
                         String output = context.getSession().peekOutput();
+                        String parentName = null;
+                        if (command.getParent() instanceof Script)
+                            parentName = ((Script) (command).getParent()).getName();
                         if(!command.isSilent()){
                             logger.warn("Nanny found idle\n  command={}\n  host={}\n  script={}\n  idle={}\n  lastLine={}",
                                     command,
                                     context.getSession().getHost().getHostName(),
-                                    script,
+                                    script + (parentName.equals(null)? "" : ":" + parentName),
                                     String.format("%5.2f", (1.0 * timestamp - lastUpdate) / 1_000),
                                     context.getSession().peekOutputTail());
                         }


### PR DESCRIPTION
This change to nanny logger identifies the current running command as well as the root command.  This helps with debugging  e.g.

13:40:29.255 [scheduled-0] WARN  perf.qdup.cmd.Dispatcher - Nanny found idle
  ....
  script=app-server-setup
  ...

becomes

13:40:29.255 [scheduled-0] WARN  perf.qdup.cmd.Dispatcher - Nanny found idle
  ...
  script=app-server-setup:build-shamrock
  ...